### PR TITLE
fix: apply the leftover apartment space adjustment correctly

### DIFF
--- a/RWH/BuildingUtils.cs
+++ b/RWH/BuildingUtils.cs
@@ -75,7 +75,7 @@ namespace RealisticWorkplacesAndHouseholds
                     //If this condition is met, what it represents is that this building has bigger apartments than the average
                     if (floorSize % sqm_per_unit < MIN_APT_SIZE)
                     {
-                        floorSize -= floorSize % sqm_per_unit;
+                        total_area -= (floorSize % sqm_per_unit) * floorCount;
                     }
                 } else
                 {


### PR DESCRIPTION
`floorSize` is never read again after this, so we need to instead apply the modification directly to `total_area`